### PR TITLE
Preview AJAX should send form data in a way that doesn't cause Rack to interpret non-ascii strings as binary.

### DIFF
--- a/app/assets/javascripts/outpost/preview.js.coffee
+++ b/app/assets/javascripts/outpost/preview.js.coffee
@@ -19,14 +19,17 @@ class outpost.Preview
                     for id,instance of CKEDITOR.instances
                         instance.updateElement()
 
-                data = form.serialize()
+                data = {}
+                _.each form.serializeArray(), (v) ->
+                    data[v['name']] = v['value']
 
                 $.ajax
-                    type: 'POST'
+                    type: data['_method'] || 'PATCH'
                     dataType: "html"
+                    contentType: "application/json; charset=utf-8"
                     url: "#{_t.options.baseUrl}/preview"
                     data:
-                        data
+                        JSON.stringify data
 
                     beforeSend: (jqXHR, settings) ->
                         _t.openWindow(target.data("windowOptions"))

--- a/lib/outpost/version.rb
+++ b/lib/outpost/version.rb
@@ -1,3 +1,3 @@
 module Outpost
-  VERSION = "0.1.6"
+  VERSION = "0.1.7"
 end


### PR DESCRIPTION
Addresses https://github.com/SCPR/SCPRv4/issues/286.