### PR TITLE
Add a simple way to show/hide elements containing contextual options …

### DIFF
--- a/app/assets/javascripts/outpost/context_options.js.coffee
+++ b/app/assets/javascripts/outpost/context_options.js.coffee
@@ -1,0 +1,33 @@
+# Set an element to display for any input(e.g. select) depending on its value.
+# Typically, this element would contain some options, but it could be
+# pretty much anything.
+
+class outpost.ContextOptions
+    defaults: {}
+
+    constructor: (@options={}) ->
+        _.defaults @options, @defaults
+
+        # Elements
+        @form          = $ @options.form
+        @containers    = $.map @options.containers, (c) -> {value: c.value, container: $(c.container)}
+        @valueField    = $ @options.valueField,     @form
+
+        @valueField.on
+            change: (event) =>
+                @getValue()
+                @toggleVisibility()
+
+        @originalStatus = @getValue()
+        @toggleVisibility()
+
+    toggleVisibility: ->
+        val = @getValue()
+        _.each @containers, (c) =>
+            if val is c.value
+                c.container.show()
+            else
+                c.container.hide()
+
+    getValue: ->
+        @status = $("option:selected", @valueField).val()


### PR DESCRIPTION
I'm adding this so that contextual options can be displayed/hidden for inputs(particularly select) similar to outpost.Publishing but where we are not depending on the status attribute of the content.  Multiple elements can be displayed or hidden for any given values for an input.  

This seemed general-purpose enough that I figured I'd add it to the main repo rather than make it into a gem.
